### PR TITLE
Fixing bad headers from slim, OAuth2 lib can now read them.

### DIFF
--- a/src/MessageBridge.php
+++ b/src/MessageBridge.php
@@ -25,8 +25,8 @@ class MessageBridge
         $badHeaders = ['Php-Auth-User','Php-Auth-Pw','Php-Auth-Digest','Auth-Type'];
         $goodHeaders = ['PHP_AUTH_USER','PHP_AUTH_PW','PHP_AUTH_DIGEST','AUTH_TYPE'];
 
-        foreach($badHeaders as $key => $badHeaderName) {
-            if(array_key_exists($badHeaderName,$headers)) {
+        foreach ($badHeaders as $key => $badHeaderName) {
+            if (array_key_exists($badHeaderName,$headers)) {
                 $headers[$goodHeaders[$key]] = $headers[$badHeaderName];
                 unset($headers[$badHeaderName]);
             }

--- a/src/MessageBridge.php
+++ b/src/MessageBridge.php
@@ -20,6 +20,18 @@ class MessageBridge
             }
         }
 
+        $headers = $request->headers()->getIterator()->getArrayCopy();
+        // Fixing bad headers from Slim
+        $badHeaders = ['Php-Auth-User','Php-Auth-Pw','Php-Auth-Digest','Auth-Type'];
+        $goodHeaders = ['PHP_AUTH_USER','PHP_AUTH_PW','PHP_AUTH_DIGEST','AUTH_TYPE'];
+
+        foreach($badHeaders as $key => $badHeaderName) {
+            if(array_key_exists($badHeaderName,$headers)) {
+                $headers[$goodHeaders[$key]] = $headers[$badHeaderName];
+                unset($headers[$badHeaderName]);
+            }
+        }
+
         return new \OAuth2\Request(
             $request->get(),
             $post,
@@ -28,7 +40,7 @@ class MessageBridge
             [],
             \Slim\Environment::getInstance()->getIterator()->getArrayCopy(),
             $request->getBody(),
-            $request->headers()->getIterator()->getArrayCopy()
+            $headers
         );
     }
 

--- a/tests/MessageBridgeTest.php
+++ b/tests/MessageBridgeTest.php
@@ -132,4 +132,41 @@ final class MessageBridgeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(0, $oauth2Request->headers('Content-Length'));
         $this->assertSame('application/json', $oauth2Request->headers('Content-Type'));
     }
+
+    /**
+     * Verify behavior of replacing bad header key names
+     *
+     * @test
+     * @covers ::newOAuth2Request
+     *
+     * @return void
+     */
+    public function newOAuth2RequestHeaderKeyNames()
+    {
+        $env = \Slim\Environment::mock(
+            [
+                'REQUEST_METHOD' => 'POST',
+                'QUERY_STRING' => 'one=1&two=2&three=3',
+                'slim.input' => 'foo=bar&abc=123',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'CONTENT_LENGTH' => 15,
+                'PHP_AUTH_USER' => 'test_client_id',
+                'PHP_AUTH_PW' => 'test_secret'
+            ]
+        );
+
+        $slimRequest = new \Slim\Http\Request($env);
+
+        $oauth2Request = MessageBridge::newOauth2Request($slimRequest);
+
+        $this->assertSame(15, $oauth2Request->headers('Content-Length'));
+        $this->assertSame('application/x-www-form-urlencoded', $oauth2Request->headers('Content-Type'));
+        $this->assertSame('123', $oauth2Request->request('abc'));
+        $this->assertSame('2', $oauth2Request->query('two'));
+        $this->assertSame('test_client_id',$oauth2Request->headers('PHP_AUTH_USER'));
+        $this->assertSame('test_secret',$oauth2Request->headers('PHP_AUTH_PW'));
+        $this->assertNull($oauth2Request->headers('Php-Auth-User'));
+        $this->assertNull($oauth2Request->headers('Php-Auth-Pw'));
+
+    }
 }


### PR DESCRIPTION
Ran into this bug trying to implement /token calls for grant_type password. User curl -u <uname>:<upass> resulted in error as the header keys were malformed.
