### PR TITLE
set request method

### DIFF
--- a/src/RequestBridge.php
+++ b/src/RequestBridge.php
@@ -28,7 +28,7 @@ class RequestBridge
             $request->getAttributes(),
             $request->getCookieParams(),
             self::convertUploadedFiles($request->getUploadedFiles()),
-            $request->getServerParams(),
+            array_merge($request->getServerParams(), ['REQUEST_METHOD' => $request->getMethod()]),
             $contents,
             self::cleanupHeaders($request->getHeaders())
         );

--- a/tests/RequestBridgeTest.php
+++ b/tests/RequestBridgeTest.php
@@ -230,4 +230,24 @@ final class RequestBridgeTest extends \PHPUnit_Framework_TestCase
             $oauth2Request->files
         );
     }
+
+    /**
+     * Verify that sets request method.
+     *
+     * @test
+     * @covers ::toOAuth2
+     *
+     * @return void
+     */
+    public function toOAuth2RequestMethodPreserved()
+    {
+        $uri = 'https://example.com/foos';
+
+        $psr7Request = new ServerRequest([], [], $uri, 'POST', 'php://input');
+
+        $oauth2Request = RequestBridge::toOAuth2($psr7Request);
+
+        $this->assertSame('POST', $psr7Request->getMethod());
+        $this->assertSame('POST', $oauth2Request->server('REQUEST_METHOD'));
+    }
 }


### PR DESCRIPTION
#### What does this PR do?
when converting PSR to oauth2 it does not set `$_SERVER[REQUEST_METHOD]` but oauth library uses it. I am trying to write tests for this and the mocked request does not have REQUEST_METHOD in $_SERVER so it creates request without request method and oauth2 lib fails

#### Checklist
- [x] Pull request contains a clear definition of changes
- [x] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
