### PR TITLE
Allow PHP 8 and bump dependencies for Slim 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /vendor/
 humbuglog.*
 composer.lock
+
+.phpunit.result.cache

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,10 +3,6 @@ filter:
         - 'vendor/*'
 before_commands:
     - 'composer install --prefer-source'
-build:
-    tests:
-        override:
-            - phpcs-run --standard=./vendor/chadicus/coding-standard/Chadicus/ruleset.xml
 tools:
     php_analyzer: true
     php_mess_detector: true

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.0 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "bshaffer/oauth2-server-php": "^1.8",
         "laminas/laminas-diactoros": "^2.8"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.0 || ^8.0",
         "bshaffer/oauth2-server-php": "^1.8",
         "zendframework/zend-diactoros": ">=1.3.2"
     },
@@ -19,9 +19,9 @@
         "sort-packages": true
     },
     "require-dev": {
-        "chadicus/coding-standard": "^1.3",
-        "php-coveralls/php-coveralls": "^1.0",
-        "phpunit/phpunit": "^5.7"
+        "chadicus/coding-standard": "^1.8",
+        "php-coveralls/php-coveralls": "^2.5",
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "psr-4": {"Chadicus\\Slim\\OAuth2\\Http\\" : "src"}

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "sort-packages": true
     },
     "require-dev": {
-        "chadicus/coding-standard": "^1.8",
+        "squizlabs/php_codesniffer": "^3.2",
         "php-coveralls/php-coveralls": "^2.5",
         "phpunit/phpunit": "^8.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.0 || ^8.0",
         "bshaffer/oauth2-server-php": "^1.8",
-        "zendframework/zend-diactoros": ">=1.3.2"
+        "laminas/laminas-diactoros": "^2.8"
     },
     "config" : {
         "sort-packages": true

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,5 @@
 <ruleset name="PHP_CodeSniffer">
     <file>.</file>
     <exclude-pattern>*/vendor/*</exclude-pattern>
-    <arg value="p" />
-    <rule ref="./vendor/chadicus/coding-standard/Chadicus"/>
+    <rule ref="PSR2"/>
 </ruleset>

--- a/src/ResponseBridge.php
+++ b/src/ResponseBridge.php
@@ -2,8 +2,8 @@
 namespace Chadicus\Slim\OAuth2\Http;
 
 use OAuth2;
-use Zend\Diactoros\Response;
-use Zend\Diactoros\Stream;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\Stream;
 
 /**
  * Static utility class for bridging OAuth2 responses to PSR-7 responses.

--- a/tests/RequestBridgeTest.php
+++ b/tests/RequestBridgeTest.php
@@ -3,8 +3,8 @@
 namespace ChadicusTest\Slim\OAuth2\Http;
 
 use Chadicus\Slim\OAuth2\Http\RequestBridge;
-use Zend\Diactoros\ServerRequest;
-use Zend\Diactoros\UploadedFile;
+use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\UploadedFile;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/RequestBridgeTest.php
+++ b/tests/RequestBridgeTest.php
@@ -5,6 +5,7 @@ namespace ChadicusTest\Slim\OAuth2\Http;
 use Chadicus\Slim\OAuth2\Http\RequestBridge;
 use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\UploadedFile;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for the \Chadicus\Slim\OAuth2\Http\RequestBridge class.
@@ -12,7 +13,7 @@ use Zend\Diactoros\UploadedFile;
  * @coversDefaultClass \Chadicus\Slim\OAuth2\Http\RequestBridge
  * @covers ::<private>
  */
-final class RequestBridgeTest extends \PHPUnit_Framework_TestCase
+final class RequestBridgeTest extends TestCase
 {
     /**
      * Verify basic behavior of toOAuth2()

--- a/tests/ResponseBridgeTest.php
+++ b/tests/ResponseBridgeTest.php
@@ -4,6 +4,7 @@ namespace ChadicusTest\Slim\OAuth2\Http;
 
 use Chadicus\Slim\OAuth2\Http\ResponseBridge;
 use OAuth2\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for the \Chadicus\Slim\OAuth2\Http\ResponseBridge class.
@@ -11,7 +12,7 @@ use OAuth2\Response;
  * @coversDefaultClass \Chadicus\Slim\OAuth2\Http\ResponseBridge
  * @covers ::<private>
  */
-final class ResponseBridgeTest extends \PHPUnit_Framework_TestCase
+final class ResponseBridgeTest extends TestCase
 {
     /**
      * Verify basic behavior of fromOAuth2()


### PR DESCRIPTION
#### What does this PR do?

This PR allows the package to be used with Slim 4 / PHP 8, and update dependencies and dev dependencies.
It also fixes tests and phpcs configuration.

I chose to mimic the `php` dependency of **Slim 4** (`^7.4 || ^8.0`) to be consistent with the framework.

After this PR, a new major release should be created, and the README should be updated accordingly to reflect the two versions: `3.x` for Slim 3 and `4.x` for Slim 4

Happy to discuss and make modifications if necessary

#### Relevant PRs in other repositories

  - https://github.com/chadicus/slim-oauth2-routes/pull/47
  - https://github.com/chadicus/slim-oauth2-middleware/pull/63
  - Original work for middleware package: https://github.com/chadicus/slim-oauth2-middleware/pull/48

#### Checklist
- [x] Pull request contains a clear definition of changes
- [x] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated -> The README should be updated afterwards
