### PR TITLE
Add Support for PHP 8

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['5.3', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['5.3', '7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['5.3', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,13 +3,12 @@ filter:
         - 'vendor/*'
 before_commands:
     - 'composer install --prefer-source'
-build:
-    tests:
-        override:
-            - phpcs-run --standard=./vendor/chadicus/coding-standard/Chadicus/ruleset.xml
 tools:
     php_analyzer: true
     php_mess_detector: true
+    php_code_sniffer:
+        config:
+            standard: PSR2
     sensiolabs_security_checker: true
     php_loc:
         excluded_dirs:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
         "bshaffer/oauth2-server-php": "^1.8",
-        "zendframework/zend-diactoros": ">=1.3.2"
+        "laminas/laminas-diactoros": "^1.8 || ^2.0"
     },
     "config" : {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,6 @@
     "name": "chadicus/slim-oauth2-http",
     "description": "Bridge components for PSR-7 and bshaffer's OAuth2 Server http messages.",
     "keywords": ["slim", "oauth2", "http", "message", "psr7", "request", "response", "bridge"],
-    "authors": [
-        {
-            "name": "Chad Gray",
-            "email": "chadwickgray@gmail.com",
-            "role": "Developer"
-        }
-    ],
     "license": "MIT",
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "sort-packages": true
     },
     "require-dev": {
-        "chadicus/coding-standard": "^1.3",
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "autoload": {
         "psr-4": {"Chadicus\\Slim\\OAuth2\\Http\\" : "src"}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^5.6 || ^7.0 || ^8.0",
         "bshaffer/oauth2-server-php": "^1.8",
         "zendframework/zend-diactoros": ">=1.3.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "sort-packages": true
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^5.7 || ^6.5 || ^9.6 || ^10.1",
         "squizlabs/php_codesniffer": "^3.7"
     },
     "autoload": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,5 +3,5 @@
     <file>.</file>
     <exclude-pattern>*/vendor/*</exclude-pattern>
     <arg value="p" />
-    <rule ref="./vendor/chadicus/coding-standard/Chadicus"/>
+    <rule ref="PSR2" />
 </ruleset>

--- a/src/ResponseBridge.php
+++ b/src/ResponseBridge.php
@@ -1,9 +1,9 @@
 <?php
 namespace Chadicus\Slim\OAuth2\Http;
 
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\Stream;
 use OAuth2;
-use Zend\Diactoros\Response;
-use Zend\Diactoros\Stream;
 
 /**
  * Static utility class for bridging OAuth2 responses to PSR-7 responses.

--- a/tests/RequestBridgeTest.php
+++ b/tests/RequestBridgeTest.php
@@ -3,8 +3,8 @@
 namespace ChadicusTest\Slim\OAuth2\Http;
 
 use Chadicus\Slim\OAuth2\Http\RequestBridge;
-use Zend\Diactoros\ServerRequest;
-use Zend\Diactoros\UploadedFile;
+use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\UploadedFile;
 
 /**
  * Unit tests for the \Chadicus\Slim\OAuth2\Http\RequestBridge class.

--- a/tests/RequestBridgeTest.php
+++ b/tests/RequestBridgeTest.php
@@ -5,6 +5,7 @@ namespace ChadicusTest\Slim\OAuth2\Http;
 use Chadicus\Slim\OAuth2\Http\RequestBridge;
 use Laminas\Diactoros\ServerRequest;
 use Laminas\Diactoros\UploadedFile;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for the \Chadicus\Slim\OAuth2\Http\RequestBridge class.
@@ -12,7 +13,7 @@ use Laminas\Diactoros\UploadedFile;
  * @coversDefaultClass \Chadicus\Slim\OAuth2\Http\RequestBridge
  * @covers ::<private>
  */
-final class RequestBridgeTest extends \PHPUnit_Framework_TestCase
+final class RequestBridgeTest extends TestCase
 {
     /**
      * Verify basic behavior of toOAuth2()

--- a/tests/ResponseBridgeTest.php
+++ b/tests/ResponseBridgeTest.php
@@ -4,6 +4,7 @@ namespace ChadicusTest\Slim\OAuth2\Http;
 
 use Chadicus\Slim\OAuth2\Http\ResponseBridge;
 use OAuth2\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for the \Chadicus\Slim\OAuth2\Http\ResponseBridge class.
@@ -11,7 +12,7 @@ use OAuth2\Response;
  * @coversDefaultClass \Chadicus\Slim\OAuth2\Http\ResponseBridge
  * @covers ::<private>
  */
-final class ResponseBridgeTest extends \PHPUnit_Framework_TestCase
+final class ResponseBridgeTest extends TestCase
 {
     /**
      * Verify basic behavior of fromOAuth2()


### PR DESCRIPTION
#### What does this PR do?
* Switch to PSR2 coding standard
* Add builds for PHP 8.0, 8.1, 8.2
* Switch to laminas for message package
* Allow newer versions of PHPUnit
* Update scrutinizer config
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
